### PR TITLE
Use name instead of family as the font map key

### DIFF
--- a/src/main/java/games/rednblack/editor/proxy/FontManager.java
+++ b/src/main/java/games/rednblack/editor/proxy/FontManager.java
@@ -120,8 +120,7 @@ public class FontManager extends Proxy {
             try {
                 if (!systemFontMap.containsValue(file.getAbsolutePath())) {
                     f = Font.createFont(Font.TRUETYPE_FONT, new FileInputStream(file.getAbsolutePath()));
-                    String name = f.getFamily();
-                    systemFontMap.put(name, file.getAbsolutePath());
+                    systemFontMap.put(f.getName(), file.getAbsolutePath());
                 }
             } catch (FontFormatException | IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
There are for example italic versions of a font and they have the same family.
Using the font name instead of the family as the key in systemFontMap prevents overwriting such entries.