### PR TITLE
Check if atlasRegion has splits data when editing ninepatch

### DIFF
--- a/plugin-9patch/src/main/java/games/rednblack/editor/plugin/ninepatch/MainPanelMediator.java
+++ b/plugin-9patch/src/main/java/games/rednblack/editor/plugin/ninepatch/MainPanelMediator.java
@@ -149,8 +149,34 @@ public class MainPanelMediator extends Mediator<MainPanel> {
 
     private void loadRegion(String name) {
         TextureAtlas atlas = plugin.getAPI().getProjectTextureAtlas();
+        validateNinePatchTextureRegion(atlas.findRegion(name));
         viewComponent.setTexture(atlas.findRegion(name));
 
         viewComponent.setListeners(plugin.getAPI().getUIStage());
+    }
+
+    private void validateNinePatchTextureRegion(TextureAtlas.AtlasRegion texture) {
+        int[] s = texture.findValue("split");
+        if (s == null) {
+            // Add splits to the atlasRegion if they are missing
+            fixNinePatch(texture);
+        }
+    }
+
+    private void fixNinePatch(TextureAtlas.AtlasRegion texture) {
+        int[] splits = {0, 0, 0, 0};
+        int[] pad = {0, 0, 0, 0};
+        texture.names = new String[] {"split", "pad"};
+        texture.values = new int[][] {splits, pad};
+
+        //remove original image
+        File originalImg = new File(plugin.getAPI().getProjectPath() + "/assets/orig/images/"+texture.name+".png");
+        originalImg.delete();
+
+        //save project
+        plugin.getAPI().saveProject();
+
+        //save split data
+        addSplitsToImageInAtlas(texture.name, splits);
     }
 }


### PR DESCRIPTION
This, together with the related [pull request in hyperlap2d-runtime-libgdx](https://github.com/rednblackgames/hyperlap2d-runtime-libgdx/pull/3) allows the application to recover if a nine patch asset was deleted from the project and is re-added while scenes still reference that removed nine patch, or if you want to replace a nine patch asset with a different image.

![recover_from_deleted_ninepatch_asset](https://user-images.githubusercontent.com/47844354/118795689-f65dc600-b8ee-11eb-827d-3fe0b114e5ec.gif)
