### PR TITLE
Fix objects being moved off grid when shift dragging

### DIFF
--- a/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
+++ b/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
@@ -247,10 +247,10 @@ public class SelectionTool extends SimpleTool {
 
             if (isShiftPressed()) {
                 if (directionVector.x == 0) {
-                    newX = dragMouseStartPosition.x;
+                    newX = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.round(dragMouseStartPosition.x);
                 }
                 if (directionVector.y == 0) {
-                    newY = dragMouseStartPosition.y;
+                    newY = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.round(dragMouseStartPosition.y);
                 }
             }
 

--- a/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
+++ b/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
@@ -247,10 +247,10 @@ public class SelectionTool extends SimpleTool {
 
             if (isShiftPressed()) {
                 if (directionVector.x == 0) {
-                    newX = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.round(dragMouseStartPosition.x);
+                    newX = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.floor(dragMouseStartPosition.x);
                 }
                 if (directionVector.y == 0) {
-                    newY = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.y: MathUtils.round(dragMouseStartPosition.y);
+                    newY = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.y: MathUtils.floor(dragMouseStartPosition.y);
                 }
             }
 

--- a/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
+++ b/src/main/java/games/rednblack/editor/view/stage/tools/SelectionTool.java
@@ -250,7 +250,7 @@ public class SelectionTool extends SimpleTool {
                     newX = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.round(dragMouseStartPosition.x);
                 }
                 if (directionVector.y == 0) {
-                    newY = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.x: MathUtils.round(dragMouseStartPosition.y);
+                    newY = (sandbox.getGridSize() > 1) ? dragMouseStartPosition.y: MathUtils.round(dragMouseStartPosition.y);
                 }
             }
 


### PR DESCRIPTION
When dragging objects while holding the shift key in a project with grid size of 1.0, the object will be moved slightly on the axis the object is locked to. See this gif:
![shift_drag_pulls_sprite_off_grid](https://user-images.githubusercontent.com/47844354/120311658-dc2ed980-c32b-11eb-807f-2dd0cabd5746.gif)

This pull request rounds the dragMouseStartPosition value if the sandbox grid size is 1.0, which kind of fixes this issue:
![fixed_maybe](https://user-images.githubusercontent.com/47844354/120311859-1d26ee00-c32c-11eb-8bda-bb477abb209c.gif)

This fix doesn't work very well on larger grid sizes since the dragMouseStartPosition can round to values that are not in step with the grid size, that is why I have only apply this to grid size of 1.
