### PR TITLE
Small live preview screen fix

### DIFF
--- a/src/main/java/games/rednblack/editor/live/LivePreviewScreen.java
+++ b/src/main/java/games/rednblack/editor/live/LivePreviewScreen.java
@@ -102,6 +102,7 @@ public class LivePreviewScreen extends ScreenAdapter implements GestureDetector.
 
     @Override
     public void resize(int width, int height) {
+        if (width == 0 || height == 0) return;
         super.resize(width, height);
         sceneLoader.resize(width, height);
     }


### PR DESCRIPTION
This should prevent live preview screen from crashing the editor when minimized